### PR TITLE
Mtvfix

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.mtv/ServiceInfo.plist
+++ b/Contents/Service Sets/com.plexapp.plugins.mtv/ServiceInfo.plist
@@ -8,12 +8,12 @@
 		<dict>
 			<key>URLPatterns</key>
 			<array>
+				<string>^http:\/\/www\.(vh1|mtv|cmt)\.com\/(full-episodes|video-clips)\/[a-z0-9]{6,}\/.+</string>
 				<string>^http:\/\/www\.(vh1|mtv|cmt)\.com\/shows\/.+\/\d{5,7}\/(playlist|video)\/(#id=\d{7})?</string>
 				<string>^http:\/\/www\.(vh1|mtv|cmt)\.com\/videos?\/.+\/\d{5,7}\/.+jhtml(.+id=\d{7})?</string>
 				<string>^http:\/\/www\.(vh1|mtv|cmt)\.com\/videos?\/(play.jhtml)?\?(.+|v)?id=\d{4,7}</string>
 				<string>^http:\/\/www\.mtvhive\.com\/videos?\/\d{6}\/</string>
 				<string>^http:\/\/www\.mtvhive\.com\/.+?\/\d{6}\/.+</string>
-				<string>^http:\/\/www\.mtv\.com\/full\-episodes\/\w{6}\/.+</string>
 			</array>
 		</dict>
 	</dict>

--- a/Contents/Service Sets/com.plexapp.plugins.mtv/ServiceInfo.plist
+++ b/Contents/Service Sets/com.plexapp.plugins.mtv/ServiceInfo.plist
@@ -14,6 +14,7 @@
 				<string>^http:\/\/www\.(vh1|mtv|cmt)\.com\/videos?\/(play.jhtml)?\?(.+|v)?id=\d{4,7}</string>
 				<string>^http:\/\/www\.mtvhive\.com\/videos?\/\d{6}\/</string>
 				<string>^http:\/\/www\.mtvhive\.com\/.+?\/\d{6}\/.+</string>
+				<string>^http:\/\/www\.mtv\.com\/full\-episodes\/\w{6}\/.+</string>
 			</array>
 		</dict>
 	</dict>


### PR DESCRIPTION
Added a new url pattern for the new format for videos for MTV shows. Included VH1 and CMT since they usually change their sites the same way, sometime down the line.

After the first commit, I noticed my version was a little different, so the 2nd commit fixes that and makes sure I am just adding the one new URL pattern.