### PR TITLE
SVT Play: Fix for PHT + new Apple TV

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.svtplay/URL/SVTPlay/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.svtplay/URL/SVTPlay/ServiceCode.pys
@@ -74,35 +74,9 @@ def MetadataObjectForURL(url):
                )
 
 ####################################################################################################
+@deferred
 def MediaObjectsForURL(url):
-    mo = []
-    
-    for resolution in [720, 576, 432, 288]:
-        mo.append(
-            MediaObject(
-                parts = [
-                    PartObject(
-                        key = 
-                            HTTPLiveStreamURL(
-                                Callback(
-                                    PlayVideo,
-                                    url = url,
-                                    resolution = resolution,
-                                    client = Client.Platform
-                                )
-                            )
-                    )
-                ],
-                video_resolution = resolution,
-                audio_channels = 2,
-                optimized_for_streaming = True
-            )
-        )
-    
-    return mo
 
-####################################################################################################
-def PlayVideo(url, resolution='720', client='', **kwargs):
     try:
         if "?" in url:
             json_obj = JSON.ObjectFromURL(url + '&output=json')
@@ -120,46 +94,38 @@ def PlayVideo(url, resolution='720', client='', **kwargs):
             playlist_url = item['url'].replace("/z/", "/i/").replace("manifest.f4m", "master.m3u8")
 
     if playlist_url:        
-        if client in ['iOS', 'Safari']:
-            # These clients can handle both https connections and
-            # URLs which contain another URL as parameter
-            #
-            # Ideally, all clients should be in this path!
-            return Redirect(playlist_url)
+        if Client.Platform in ['iOS', 'Safari', 'tvOS']:
+            return [
+                MediaObject(
+                    parts = [PartObject(key = HTTPLiveStreamURL(playlist_url))],
+                    video_resolution = 720,
+                    audio_channels = 2,
+                    optimized_for_streaming = True
+                )
+            ]
         else:
             streams = GetHLSStreams(playlist_url)
-            
-            min_resolution_diff = 1000000000 # some huge number to get it started
-            hls_url             = streams[0]['url']
-            
+
+            mo = []
             for stream in streams:
-                diff = abs(resolution - stream['resolution'])
-                if diff < min_resolution_diff:
-                    min_resolution_diff = diff
-                    hls_url             = stream['url']
-
-            cookies = HTTP.CookiesForURL(playlist_url)
-    
-            headers               = {}
-            headers['Cookie']     = cookies
-            headers['User-Agent'] = USER_AGENT
-
-            playlist = HTTP.Request(hls_url, headers = headers, cacheTime = 0).content
-            
-            if not 'https' in playlist:
-                # No https connection and the extra URLs have
-                # been stripped out
-                # -> Just redirect and let the client handle everything
-                return Redirect(hls_url)
-            else:
-                # We need to apply a patch for clients without SSL support
-                # Note that this includes PMS when transcoding/remuxing for a client,
-                # for example for Chromecast
-                return Redirect(
-                    Callback(CreatePatchedPlaylist, url = hls_url, cookies = cookies)
+                if not '?' in stream['url']:
+                    stream['url'] = stream['url'] + '?null=' # Fix for Samsung
+                
+                mo.append(
+                    MediaObject(
+                        parts = [
+                            PartObject(
+                                key = HTTPLiveStreamURL(stream['url'])
+                            )
+                        ],
+                        video_resolution = stream['resolution'],
+                        audio_channels = 2,
+                        optimized_for_streaming = True,
+                        bitrate = int(stream['bitrate'] / 1024)
+                    )
                 )
-    else:
-        raise Ex.MediaNotAvailable
+                
+            return mo
 
 ####################################################################################################
 def GetHLSStreams(url):
@@ -205,33 +171,3 @@ def GetHLSStreams(url):
 
     return sorted_streams
 
-####################################################################################################
-def CreatePatchedPlaylist(url, cookies):
-    headers               = {}
-    headers['Cookie']     = cookies
-    headers['User-Agent'] = USER_AGENT
-
-    original_playlist = HTTP.Request(url, headers = headers, cacheTime = 0).content
-    new_playlist = ''
-
-    for line in original_playlist.splitlines():
-        if line.startswith('#EXT-X-KEY'):
-            original_key_url = RE_KEY_URI.search(line).groups()[0]
-            new_key_url = Callback(ContentOfURL, url = original_key_url, cookies = cookies)
-            new_playlist = new_playlist + line.replace(original_key_url, new_key_url) + '\n'
-        elif line.startswith('http'):
-            original_segment_url = line
-            new_segment_url = Callback(ContentOfURL, url = original_segment_url, cookies = cookies)
-            new_playlist = new_playlist + new_segment_url + '\n'
-        else:
-            new_playlist = new_playlist + line + '\n'
-    
-    return new_playlist
-    
-####################################################################################################
-def ContentOfURL(url, cookies):
-    headers               = {}
-    headers['Cookie']     = cookies
-    headers['User-Agent'] = USER_AGENT
-    
-    return HTTP.Request(url, headers = headers, cacheTime = 0).content


### PR DESCRIPTION
Since the introduction of the SSL features in PMS, the patch for PHT is not working anymore(in a reliable way) since you have to 'Disable Secure Connections' in order for it to work.

This update will make PHT be able to play VOD programs independent of PMS secure connection setting, e.g. you can now set 'Required'. 

An update for the new Apple TV is also included so that client will get access to the master playlist(which enables subtitles etc)