### PR TITLE
FOX: SSL certificate now valid -> Let compatible clients get access to original url

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.fox/URL/FOX/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.fox/URL/FOX/ServiceCode.pys
@@ -72,24 +72,37 @@ def MediaObjectsForURL(url):
 
         mo = []
 
-        return [
-            MediaObject(
-                video_resolution = video_resolution,
-                audio_channels = 2,
-                parts = [
-                    PartObject(
-                        key =
-                            HTTPLiveStreamURL(
-                                Callback(
-                                    PlayVideo,
-                                    url = video_url[0],
-                                    video_resolution = video_resolution
-                                )
+        if Client.Platform in ['Android', 'iOS', 'Roku', 'Safari', 'tvOS', 'Mystery 4', 'Konvergo']:
+            return [
+                MediaObject(
+                    video_resolution = 720,
+                    audio_channels = 2,
+                    parts = [
+                        PartObject(
+                            key = HTTPLiveStreamURL(url = video_url[0])
                         )
-                    )
-                ],
-            ) for video_resolution in ['720', '576', '360', '270', '226']   
-        ] 
+                    ],
+                )   
+            ]        
+        else:
+            return [
+                MediaObject(
+                    video_resolution = video_resolution,
+                    audio_channels = 2,
+                    parts = [
+                        PartObject(
+                            key =
+                                HTTPLiveStreamURL(
+                                    Callback(
+                                        PlayVideo,
+                                        url = video_url[0],
+                                        video_resolution = video_resolution
+                                    )
+                            )
+                        )
+                    ],
+                ) for video_resolution in ['720', '576', '360', '270', '226']   
+            ]
 
     raise Ex.MediaNotAvailable
 

--- a/Contents/Service Sets/com.plexapp.plugins.fox/URL/FOX/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.fox/URL/FOX/ServiceCode.pys
@@ -111,11 +111,7 @@ def PlayVideo(url, video_resolution = '720', **kwargs):
 
     hls_url = GetSpecificResolutionURL(url, video_resolution)
 
-    # We need to redirect to local PMS due to links
-    # are using SSL(https) with a missing certificate.
-    # (PMS doesn't care about this it seems)
-    # The domain missing a certificate is fbchdvod-f.akamaihd.net
-    # I guess the FOX iOS App has a built in exception for this domain?
+    # Use "proxy" for clients like PHT(lack of SSL support)
     return Redirect(
         Callback(CreatePatchedPlaylist, url = hls_url, cookies = HTTP.CookiesForURL(url))
     )


### PR DESCRIPTION
Seems like the akamai domain finally got a valid SSL certificate ... 

We still need to keep the alternative for clients like PHT(no SSL support).