### PR TITLE
Fix thumb error

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.abcfamily/URL/ABC Family/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.abcfamily/URL/ABC Family/ServiceCode.pys
@@ -31,7 +31,8 @@ def MetadataObjectForURL(url):
 		season = None
 		index = None
 
-	thumb = html.xpath('//meta[@name="ogImageFromApi"]/@content')[0]
+	try: thumb = html.xpath('//meta[@name="ogImageFromApi"]/@content')[0]
+	except: thumb = html.xpath('//link[@rel="image_src"]/@href')[0]
 
 	return EpisodeObject(
 		show = show_title,


### PR DESCRIPTION
Fix thumb error in MetadataforURL function due to a page not having a thumb. Added an except that pulls a default logo image.