### PR TITLE
Add bitrates to mediaobject + add framerate

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.iplayer/URL/BBC iPlayer/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.iplayer/URL/BBC iPlayer/ServiceCode.pys
@@ -3,7 +3,7 @@ HTTP_HEADERS = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) A
 RE_PID = Regex('iplayer/episode/([^/$]{8})')
 RE_VPID = Regex('"vpid" *: *"(.+?)"')
 
-HLS_CLIENTS = ['Android', 'iOS', 'Roku', 'Safari', 'tvOS']
+HLS_CLIENTS = ['Android', 'iOS', 'Roku', 'Safari', 'tvOS', 'Mystery 4', 'Konvergo']
 
 STREAMS = {
     1080: int(8582000/1024),

--- a/Contents/Service Sets/com.plexapp.plugins.iplayer/URL/BBC iPlayer/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.iplayer/URL/BBC iPlayer/ServiceCode.pys
@@ -5,6 +5,12 @@ RE_VPID = Regex('"vpid" *: *"(.+?)"')
 
 HLS_CLIENTS = ['Android', 'iOS', 'Roku', 'Safari', 'tvOS']
 
+STREAMS = {
+    1080: int(8582000/1024),
+    720: int(5476000/1024),
+    540: int(3083000/1024),
+    360: int(832000/1024)
+}
 ####################################################################################################
 def NormalizeURL(url):
 
@@ -131,22 +137,28 @@ def MediaObjectsForURL(url):
 
     media_selector_url = 'http://open.live.bbc.co.uk/mediaselector/5/select/version/2.0/format/json/mediaset/apple-ipad-hls/vpid/%s' % (vpid)
 
-    return [
-        MediaObject(
-            protocol = 'hls',
-            container = 'mpegts',
-            video_codec = VideoCodec.H264,
-            video_resolution = resolution,
-            audio_codec = AudioCodec.AAC,
-            audio_channels = 2,
-            optimized_for_streaming = True,
-            parts = [
-                PartObject(
-                    key = Callback(PlayVideo, post_url=media_selector_url, media_selector_url=media_selector_url, vpid=vpid, resolution=resolution, ext='m3u8')
-                )
-            ]
-        ) for resolution in ['1080', '720', '540', '396', '288']
-    ]
+    mo = []
+    for resolution in reversed(sorted(STREAMS)):
+        mo.append(
+            MediaObject(
+                protocol = 'hls',
+                container = 'mpegts',
+                video_codec = VideoCodec.H264,
+                video_resolution = resolution,
+                bitrate = STREAMS[resolution],
+                audio_codec = AudioCodec.AAC,
+                video_frame_rate = 25,
+                audio_channels = 2,
+                optimized_for_streaming = True,
+                parts = [
+                    PartObject(
+                        key = Callback(PlayVideo, post_url=media_selector_url, media_selector_url=media_selector_url, vpid=vpid, resolution=resolution, ext='m3u8')
+                    )
+                ]
+            )
+        )
+    
+    return mo
 
 ####################################################################################################
 @indirect

--- a/Contents/Service Sets/com.plexapp.plugins.iplayer/URL/BBC iPlayer/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.iplayer/URL/BBC iPlayer/ServiceCode.pys
@@ -3,7 +3,7 @@ HTTP_HEADERS = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) A
 RE_PID = Regex('iplayer/episode/([^/$]{8})')
 RE_VPID = Regex('"vpid" *: *"(.+?)"')
 
-HLS_CLIENTS = ['Android', 'iOS', 'Roku', 'Safari', 'tvOS', 'Mystery 4', 'Konvergo']
+HLS_CLIENTS = ['Android', 'iOS', 'Roku', 'Safari', 'tvOS', 'Mystery 4']
 
 STREAMS = {
     1080: int(8582000/1024),


### PR DESCRIPTION
This will help clients to better choose the correct source resolution, i.e. if omitting the bitrate PMS will always choose the max bitrate resolution when transcoding. Without this update it will lead to buffering if the bandwidth is not sufficient on the PMS computer: https://forums.plex.tv/discussion/198650/iplayer-streaming#latest

