### PR TITLE
TV Land - Add media objects

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.tvland/URL/TVLand/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.tvland/URL/TVLand/ServiceCode.pys
@@ -4,9 +4,6 @@ NAMESPACES = {'media': 'http://search.yahoo.com/mrss/'}
 RE_FIX_XML = Regex('(<!--.*?-->)')
 RE_BITRATE = Regex('_(\d+)_?[^._]*\.mp4')
 
-MediaObject.audio_channels = 2
-MediaObject.optimized_for_streaming = True
-
 ####################################################################################################
 def NormalizeURL(url):
 
@@ -164,7 +161,10 @@ def MediaObjectsForURL(url):
 			MediaObject(
 				parts = parts,
 				bitrate = bitrate,
-				video_resolution = video_resolution
+				video_resolution = video_resolution,
+				audio_channels = 2,
+				video_codec = VideoCodec.H264,
+				audio_codec = AudioCodec.AAC
 			)
 		)
 


### PR DESCRIPTION
Set media object attributes directly on the object and Add video_codec and audio_codec to MediaObject to match other Viacom channels