### PR TITLE
History - Add URL pattern

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.historychannel/ServiceInfo.plist
+++ b/Contents/Service Sets/com.plexapp.plugins.historychannel/ServiceInfo.plist
@@ -10,6 +10,7 @@
 			<array>
 				<string>^http://www.history.com/(shows|topics)/.+/videos/.+</string>
 				<string>^http://www.history.com/videos/.+</string>
+				<string>^http:\/\/www\.history\.com\/shows\/[^\/]+\/season-\d{1,2}\/episode-\d{1,2}(.+)?</string>
 			</array>
 		</dict>
 	</dict>


### PR DESCRIPTION
Add URL pattern for website URLs. The URLs used by the channel will actually redirect to the season/episode URL that is used by the website