### PR TITLE
Lifetime - Add URL pattern

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.lifetime/ServiceInfo.plist
+++ b/Contents/Service Sets/com.plexapp.plugins.lifetime/ServiceInfo.plist
@@ -9,6 +9,7 @@
 			<key>URLPatterns</key>
 			<array>
 				<string>^(?!.*full-episodes)http://www.mylifetime.com/(shows|movies)/.+/video/.+</string>
+				<string>^http:\/\/www\.mylifetime\.com\/shows\/[^\/]+\/season-\d{1,2}\/episode-\d{1,2}(.+)?</string>
 			</array>
 		</dict>
 	</dict>


### PR DESCRIPTION
Add URL pattern for website URLs. The URLs used by the channel will actually redirect to the season/episode URL that is used by the website