### PR TITLE
Added twitch api client id to HTTP headers

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.twitchtv/URL/Twitch.tv/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.twitchtv/URL/Twitch.tv/ServiceCode.pys
@@ -1,6 +1,7 @@
 STREAM_DATA = 'https://api.twitch.tv/kraken/streams/%s'
 HLS_TOKEN_URL = 'http://api.twitch.tv/api/channels/%s/access_token'
 HLS_PLAYLIST_URL = 'http://usher.twitch.tv/api/channel/hls/%s.m3u8?token=%s&sig=%s'
+CLIENT_ID = 'gzux2tt85x9ppnnxyh7czkfiovtxtd7'
 
 ####################################################################################################
 def NormalizeURL(url):
@@ -13,6 +14,7 @@ def MetadataObjectForURL(url):
 	user_id = GetUserId(url)
 
 	try:
+		HTTP.Headers['Client-ID'] = CLIENT_ID
 		video = JSON.ObjectFromURL(STREAM_DATA % user_id, cacheTime=0)
 	except:
 		raise Ex.MediaNotAvailable
@@ -58,6 +60,7 @@ def PlayVideo(url, **kwargs):
 	user_id = GetUserId(url)
 
 	try:
+		HTTP.Headers['Client-ID'] = CLIENT_ID
 		token = JSON.ObjectFromURL(HLS_TOKEN_URL % user_id, cacheTime=0)
 	except:
 		raise Ex.MediaNotAvailable


### PR DESCRIPTION
Twitch.tv now returns HTTP error 400 for API calls without a client id. 
Registered application with Twitch as "Plex-plugin: Twitch.Tv".
Added client id to HTTP headers in Twitch.tv plugin ServiceCode.pys.