### PR TITLE
South Park - Fix short parts issue

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.southpark/URL/South Park/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.southpark/URL/South Park/ServiceCode.pys
@@ -90,9 +90,13 @@ def MediaObjectsForURL(url):
 		except:
 			raise Ex.MediaNotAvailable
 
+		# Skip parts that are too short and cause issues in some Plex players
+		part_duration = hls_data.xpath('//rendition/@duration')[0]
+		if int(part_duration) <8:
+			continue
 		# Create part for the video section
 		part = {}
-		part['duration'] = hls_data.xpath('//rendition/@duration')[0]
+		part['duration'] = part_duration
 		part['hls_url'] = hls_data.xpath('//rendition/src/text()')[0]
 		available_streams.append(part)
 


### PR DESCRIPTION
Some Plex player apps will not play all parts if they follow a very short part, so until the Plex player apps update their code, this will allow users to skip the short flash screen at the beginning that causes
parts not to play.

This should be addressed and fixed by each of the Plex player apps, but adding this exception will allow users to watch older Southpark videos until the apps resolve the issue.