### PR TITLE
Comedy Central - Update URL Pattern

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.comedycentral/ServiceInfo.plist
+++ b/Contents/Service Sets/com.plexapp.plugins.comedycentral/ServiceInfo.plist
@@ -8,7 +8,7 @@
 		<dict>
 			<key>URLPatterns</key>
 			<array>
-				<string>^(?!.*\/press\/)http:\/\/(www|tosh)\.cc\.com\/(episodes|video\-clips)\/[^/]{6}\/.+</string>
+				<string>^(?!.*\/press\/)http:\/\/(www|tosh)\.cc\.com\/((full-)?episodes|video\-clips)\/[^/]{6}\/.+</string>
 			</array>
 		</dict>
 	</dict>


### PR DESCRIPTION
Update URL pattern to include both URLs with "/episodes/" and "/full-episodes/" to accept full standup shows which still use the URLs with "/full-episodes/".