### PR TITLE
Tv4play fix for broken service

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.tv4play/URL/TV4 Play/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.tv4play/URL/TV4 Play/ServiceCode.pys
@@ -4,7 +4,7 @@ RE_VIDEO_ID     = Regex('(?<=video_id=)[0-9]+')
 RE_SHOW_EPISODE = Regex('(.*) *(Del) *([0-9]+) *(.*)', Regex.IGNORECASE)
 
 API_METADATA_URL  = 'http://webapi.tv4play.se/play/video_assets/%s'
-API_VIDEO_URL = 'https://prima.tv4play.se/%s'
+API_VIDEO_URL = 'http://prima.tv4play.se/%s'
 
 PROXY_URL     = 'http://papi.tv4play.se/playback/hls/hlsproxy.m3u8?hlsurl=%s&subsurl=%s'
 

--- a/Contents/Service Sets/com.plexapp.plugins.tv4play/URL/TV4 Play/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.tv4play/URL/TV4 Play/ServiceCode.pys
@@ -127,13 +127,6 @@ def GetURLs(id):
     headers = {}
     headers['User-Agent'] = USER_AGENT
     
-    cookies = None
-    if Prefs['premium'] and Prefs['email'] and Prefs['password']:
-        cookies = Login()
-        
-    if cookies:
-        headers['Cookie'] = cookies
-    
     is_live = IsLive(id)
     
     if not is_live:


### PR DESCRIPTION
- Don't use https since the cipher negotiation fails
- Prepare removal of login since Premium is not available anymore. The rest of the removal will be done at a later time to better sync it with the TV4Play.bundle(so that this change will hopefully be unnoticeable for the user)