### PR TITLE
Ted Talks - update URL pattern

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.ted/ServiceInfo.plist
+++ b/Contents/Service Sets/com.plexapp.plugins.ted/ServiceInfo.plist
@@ -8,7 +8,7 @@
 		<dict>
 			<key>URLPatterns</key>
 			<array>
-				<string>^https:\/\/www\.ted\.com\/talks\/[a-z0-9_]+</string>
+				<string>^https?:\/\/www\.ted\.com\/talks\/[a-z0-9_]+</string>
 			</array>
 		</dict>
 	</dict>


### PR DESCRIPTION
They changed from https to http in thier URLs and so the channel was failing. Added question mark to URL patttern to prevent this for any future changes.