### PR TITLE
A&E Networks - Add resolution to media objects

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.aetv/URL/AETV/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.aetv/URL/AETV/ServiceCode.pys
@@ -55,6 +55,7 @@ def MediaObjectsForURL(url):
     MediaObject(
       protocol = 'hls',
       container = 'mpegts',
+      video_resolution = 540,
       parts = [
         PartObject(
           key=HTTPLiveStreamURL(Callback(PlayVideo, url=url))

--- a/Contents/Service Sets/com.plexapp.plugins.historychannel/URL/History Channel/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.historychannel/URL/History Channel/ServiceCode.pys
@@ -55,6 +55,7 @@ def MediaObjectsForURL(url):
     MediaObject(
       protocol = 'hls',
       container = 'mpegts',
+      video_resolution = 540,
       parts = [
         PartObject(
           key=HTTPLiveStreamURL(Callback(PlayVideo, url=url))

--- a/Contents/Service Sets/com.plexapp.plugins.lifetime/URL/Lifetime/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.lifetime/URL/Lifetime/ServiceCode.pys
@@ -55,6 +55,7 @@ def MediaObjectsForURL(url):
     MediaObject(
       protocol = 'hls',
       container = 'mpegts',
+      video_resolution = 540,
       parts = [
         PartObject(
           key=HTTPLiveStreamURL(Callback(PlayVideo, url=url))


### PR DESCRIPTION
Add resolution for media objects for all A&E Network URL services (Lifetime, AETV, and History Channel)