### PR TITLE
Liveleak: Fix in URL pattern to support all videos from plugin

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.liveleak/ServiceInfo.plist
+++ b/Contents/Service Sets/com.plexapp.plugins.liveleak/ServiceInfo.plist
@@ -8,7 +8,7 @@
 		<dict>
 			<key>URLPatterns</key>
 			<array>
-				<string>^https:\/\/www\.liveleak\.com\/view\?t=.{5}_\d{10}</string>
+				<string>^https:\/\/www\.liveleak\.com\/view\?t=.+_\d{10}</string>
 			</array>
 		</dict>
 	</dict>


### PR DESCRIPTION
Sometimes there are 4 instead of 5 characters before the underscore