### PR TITLE
https for token retrieval

### DIFF
--- a/Contents/Service Sets/com.plexapp.plugins.twitchtv/URL/Twitch.tv/ServiceCode.pys
+++ b/Contents/Service Sets/com.plexapp.plugins.twitchtv/URL/Twitch.tv/ServiceCode.pys
@@ -1,5 +1,5 @@
 STREAM_DATA = 'https://api.twitch.tv/kraken/streams/%s'
-HLS_TOKEN_URL = 'http://api.twitch.tv/api/channels/%s/access_token'
+HLS_TOKEN_URL = 'https://api.twitch.tv/api/channels/%s/access_token'
 HLS_PLAYLIST_URL = 'http://usher.twitch.tv/api/channel/hls/%s.m3u8?token=%s&sig=%s'
 
 HTTP_HEADERS = {


### PR DESCRIPTION
fix for:
MediaNotAvailable exception on line 68 when watching streams
Due to service call response on line 66: "Requests must be made over SSL"